### PR TITLE
Add remove rows columns without clear

### DIFF
--- a/designs.js
+++ b/designs.js
@@ -92,14 +92,27 @@ function decrement (i, val){
 }
 
 ////////////// difference between input and actual table
-let gridRows = inputRows.val();
-let currentGridRows = 0;
-let rowsDiff = gridRows - currentGridRows;
-
+// This function executed at the start of buildGrid finds the difference between the number of rows indicated in the input vs the actual current number of rows just before building. rowsDiff is then used as the number of loops to build. in effect it adds a single row when they match or as many as needed when they don't
+let rowsDiff = 0;
+let columnsDiff = 0;
 function countRows(){
+    let currentGridRows = 0;
+    let gridRows = inputRows.val();
     currentGridRows = pixelCanvas.children('tr').length;
+    rowsDiff = gridRows - currentGridRows;
     console.log(currentGridRows);
+    console.log(gridRows);
     console.log(rowsDiff);
+}
+//////////////
+function countColumns(){
+    let currentGridColumns = 0;
+    let gridColumns = inputColumns.val();
+    currentGridColumns = pixelCanvas.children('td').length; //////////////
+    columnDiff = gridColumns - currentGridColumns;
+    // console.log(currentGridRows);
+    // console.log(gridRows);
+    // console.log(rowsDiff);
 }
 
 
@@ -111,7 +124,6 @@ function gridBuilder (scale, axis){
     axis.val(scale);
     buildGrid(scale, axis);
     test = axis.val();
-    countRows();
     // console.log(test);
 }
 
@@ -119,19 +131,22 @@ function gridBuilder (scale, axis){
 // This function adds a row without resetting the grid (painting persists), adds a column (but doesn't appear if row=0), the remove function is not yet implemented
 // the main issue is that inputting numbers manually puts the Btns out of sync with the actual input
 function buildGrid(scale, axis){
+    countRows();
     if (scale === increment && axis === inputRows){
-        const addRow = $("<tr></tr>");
-        pixelCanvas.append(addRow);
-        for(let c = 1; c <= inputColumns.val(); c++){
-            const addColumn = $("<td></td>");
-            addRow.append(addColumn);
+        for (let r = 1; r <= rowsDiff; r++){
+            const addRow = $("<tr></tr>");
+            pixelCanvas.append(addRow);
+            for(let c = 1; c <= inputColumns.val(); c++){
+                const addColumn = $("<td></td>");
+                addRow.append(addColumn);
+            }
         }
     } else if (scale === decrement && axis === inputRows){
         row.remove();
     } else if (scale === increment && axis === inputColumns){
         pixelCanvas.children().append(column);
     } else {
-       column.remove();
+        column.remove();
     }
 }
 

--- a/designs.js
+++ b/designs.js
@@ -99,7 +99,7 @@ function countRows(){
     let gridRows = inputRows.val();
     let currentGridRows = 0;
     currentGridRows = pixelCanvas.children('tr').length;
-    rowsDiff = gridRows - currentGridRows;
+    rowsDiff = Math.abs(gridRows - currentGridRows);
     // console.log(currentGridRows);
     // console.log(gridRows);
     // console.log(rowsDiff);
@@ -109,7 +109,7 @@ function countColumns(){
     let gridColumns = inputColumns.val();
     let currentGridColumns = 0;
     currentGridColumns = pixelCanvas.children().first().children().length;
-    columnsDiff = gridColumns - currentGridColumns;
+    columnsDiff = Math.abs(gridColumns - currentGridColumns);
     // console.log(currentGridColumns);
     // console.log(gridColumns);
     // console.log(columnsDiff);
@@ -117,14 +117,17 @@ function countColumns(){
 
 
 // This with test = axis.val(); executed in gridBuilder, means the value of button and input are now always the same. maybe add btn param to make it work for all four buttons
-let test = addRowBtn.val();
+let addRowBtnValue = addRowBtn.val();
+let removeRowBtnValue = removeRowBtn.val();
+let addColumnBtnValue = addColumnBtn.val();
+let removeColumnBtnValue = removeColumnBtn.val();
 
 // Build grid & update input. scale = increment or decrement. axis = row or column
-function gridBuilder (scale, axis){
+function gridBuilder (scale, axis, btn){
     axis.val(scale);
     buildGrid(scale, axis);
-    test = axis.val();
-    // console.log(test);
+    btn = axis.val();
+    // console.log(btn);
 }
 
 ////////////////////////////////////////////////////
@@ -143,38 +146,46 @@ function buildGrid(scale, axis){
             }
         }
     } else if (scale === decrement && axis === inputRows){
-        pixelCanvas.children().last().remove();
+        for (let r = 1; r <= rowsDiff; r++){
+            pixelCanvas.children().last().remove();
+        }
     } else if (scale === increment && axis === inputColumns){
-        pixelCanvas.children().append(column);
+        for (let c = 1; c <= columnsDiff; c++){
+            pixelCanvas.children().append(column);
+        }
     } else {
-        $('tr').each(function(){
-            $(this).find("td:last").remove();
-        });
+        for (let c = 1; c <= columnsDiff; c++){
+            $('tr').each(function(){
+                $(this).find("td:last").remove();
+            });
+        }
     }
 }
 
 // Grid-building buttons event listeners
 addRowBtn.click(function(){
-    gridBuilder(increment, inputRows);
+    gridBuilder(increment, inputRows, addRowBtnValue);
 });
 
 removeRowBtn.click(function(){
-    gridBuilder(decrement, inputRows);
+    // builds missing rows before removing
+    buildGrid(increment, inputRows);
+    gridBuilder(decrement, inputRows, removeRowBtnValue);
 });
 
 addColumnBtn.click(function(){
     //Checks if there are rows already created
     if ( pixelCanvas.children('tr').length ) {
-        gridBuilder(increment, inputColumns);
+        gridBuilder(increment, inputColumns, addColumnBtnValue);
     } else {
         // Creates rows
        buildGrid(increment, inputRows);
-        gridBuilder(increment, inputColumns);
+        gridBuilder(increment, inputColumns, addColumnBtnValue);
     }
 });
 
 removeColumnBtn.click(function(){
-    gridBuilder(decrement, inputColumns);
+    gridBuilder(decrement, inputColumns, removeColumnBtnValue);
 });
 
 // DRAW

--- a/designs.js
+++ b/designs.js
@@ -91,6 +91,18 @@ function decrement (i, val){
     return +val -1;
 }
 
+////////////// difference between input and actual table
+let gridRows = inputRows.val();
+let currentGridRows = 0;
+let rowsDiff = gridRows - currentGridRows;
+
+function countRows(){
+    currentGridRows = pixelCanvas.children('tr').length;
+    console.log(currentGridRows);
+    console.log(rowsDiff);
+}
+
+
 // This with test = axis.val(); executed in gridBuilder, means the value of button and input are now always the same. maybe add btn param to make it work for all four buttons
 let test = addRowBtn.val();
 
@@ -99,7 +111,8 @@ function gridBuilder (scale, axis){
     axis.val(scale);
     buildGrid(scale, axis);
     test = axis.val();
-    console.log(test);
+    countRows();
+    // console.log(test);
 }
 
 ////////////////////////////////////////////////////

--- a/designs.js
+++ b/designs.js
@@ -148,7 +148,7 @@ function buildGrid(scale, axis){
         pixelCanvas.children().append(column);
     } else {
         $('tr').each(function(){
-            $('td').last().remove(); ///////////////////////
+            $(this).find("td:last").remove();
         });
     }
 }

--- a/designs.js
+++ b/designs.js
@@ -55,6 +55,27 @@ function makeGrid(){
 submitGridSize.click(makeGrid);
 
 // GRID BUILDER
+
+//////////////////////////////////////
+/*
+// Option with disabled typing in number input
+function reset(){
+    clearGrid();
+    colorInput.val('#000000');
+    selectedColor = colorInput.val();
+    inputRows.val(10);
+    inputColumns.val(10);
+    makeGrid();
+}
+
+// Start with a 10x10 grid
+makeGrid();
+// Disable inputting numbers
+$("[type='number']").keypress(function (evt) {
+    evt.preventDefault();
+}); */
+
+
 // Add/remove row/column
 const addRowBtn = $('#add-row');
 const removeRowBtn = $('#remove-row');
@@ -70,10 +91,30 @@ function decrement (i, val){
     return +val -1;
 }
 
-// Build grid. scale = increment or decrement. axis = row or column
+// Build grid & update input. scale = increment or decrement. axis = row or column
 function gridBuilder (scale, axis){
     axis.val(scale);
-    makeGrid();
+    buildGrid(scale, axis);
+}
+
+////////////////////////////////////////////////////
+// This function adds a row without resetting the grid (painting persists), adds a column (but doesn't appear if row=0), the remove function is not yet implemented
+// the main issue is that inputting numbers manually puts the Btns out of sync with the actual input
+function buildGrid(scale, axis){
+    if (scale === increment && axis === inputRows){
+        const addRow = $("<tr></tr>");
+        pixelCanvas.append(addRow);
+        for(let c = 1; c <= inputColumns.val(); c++){
+            const addColumn = $("<td></td>");
+            addRow.append(addColumn);
+        }
+    } else if (scale === decrement && axis === inputRows){
+        row.remove();
+    } else if (scale === increment && axis === inputColumns){
+        pixelCanvas.children().append(column);
+    } else {
+       column.remove();
+    }
 }
 
 // Grid-building buttons event listeners
@@ -148,6 +189,20 @@ pixelCanvas
     .on('click', 'td', draw)
     .on('mousedown', 'td', drag);
 
+
+
+// convert rgb to hex on click
+/* let thisHex = pixelCanvas.on('click', 'td', function(){
+    rgbToHex( $(this).css('background-color') );
+
+});
+function rgbToHex(rgb){
+    rgb = rgb.match(/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i);
+    return (rgb && rgb.length === 4) ? "#" +
+     ("0" + parseInt(rgb[1],10).toString(16)).slice(-2) +
+     ("0" + parseInt(rgb[2],10).toString(16)).slice(-2) +
+     ("0" + parseInt(rgb[3],10).toString(16)).slice(-2) : '';
+} */
 
 
 // This can log the individual cell clicked, as well as the start and end cell on drag. It serves no purpose in this project any longer. But I made it, and it works, so it's staying here for now!!

--- a/designs.js
+++ b/designs.js
@@ -55,13 +55,110 @@ function makeGrid(){
 submitGridSize.click(makeGrid);
 
 // GRID BUILDER
-//////////////////////////////////////
+////////////////////////////////////////////////
 
 // Add/remove row/column buttons
 const addRowBtn = $('#add-row');
 const removeRowBtn = $('#remove-row');
 const addColumnBtn = $('#add-column');
 const removeColumnBtn = $('#remove-column');
+
+// Event listeners for grid-building buttons
+let clickAndHold;
+
+addRowBtn.mousedown(function(){
+    // Allow single click or click and hold to add multiple
+    clickAndHold = setInterval(function(){
+        gridBuilder(increment, inputRows, addRowBtnValue);
+    }, 80);
+}).mouseup(function(){
+    clearInterval(clickAndHold);
+});
+
+removeRowBtn.mousedown(function(){
+    // builds missing rows before removing
+    buildGrid(increment, inputRows);
+    clickAndHold = setInterval(function(){
+        gridBuilder(decrement, inputRows, removeRowBtnValue);
+    }, 80);
+}).mouseup(function(){
+    clearInterval(clickAndHold);
+});
+
+addColumnBtn.mousedown(function(){
+    // builds grid if it's not there yet
+    buildGrid(increment, inputRows);
+    clickAndHold = setInterval(function(){
+        gridBuilder(increment, inputColumns, addColumnBtnValue);
+    }, 80);
+}).mouseup(function(){
+    clearInterval(clickAndHold);
+});
+
+removeColumnBtn.mousedown(function(){
+    // builds grid before removing column
+    buildGrid(increment, inputRows);
+    clickAndHold = setInterval(function(){
+        gridBuilder(decrement, inputColumns, removeColumnBtnValue);
+    }, 80);
+}).mouseup(function(){
+    clearInterval(clickAndHold);
+});
+
+// Add/remove rows/columns buttons value
+let addRowBtnValue = addRowBtn.val();
+let removeRowBtnValue = removeRowBtn.val();
+let addColumnBtnValue = addColumnBtn.val();
+let removeColumnBtnValue = removeColumnBtn.val();
+
+// listen to change in input and update btn value
+inputRows.on('keyup mouseup', function(){
+    addRowBtnValue = inputRows.val();
+    removeRowBtnValue = inputRows.val();
+});
+
+inputColumns.on('keyup mouseup', function(){
+    addColumnBtnValue = inputColumns.val();
+    removeColumnBtnValue = inputColumns.val();
+});
+
+// Listen to enter key on input and construct grid
+inputRows.keypress(function(event){
+    const key = (event.keyCode ? event.keyCode : event.which);
+    if (key == '13'){
+        countRows();
+        countColumns()
+        if (currentGridRows < inputRows.val()){
+            constructRows();
+        } else {
+            eliminateRows();
+        }
+    }
+});
+
+inputColumns.keypress(function(event){
+    const key = (event.keyCode ? event.keyCode : event.which);
+    if (key == '13'){
+        countRows();
+        countColumns()
+        if (currentGridColumns < inputColumns.val()){
+            if (currentGridColumns == 0){
+                buildGrid(increment, inputRows);
+            } else {
+                constructColumns();
+            }
+        } else {
+            eliminateColumns();
+        }
+    }
+});
+
+// Build grid, update input, & update btn value. scale = increment or decrement. axis = row or column. btn = add/remove rows/columns buttons
+function gridBuilder (scale, axis, btn){
+    axis.val(scale);
+    buildGrid(scale, axis);
+    btn = axis.val();
+}
 
 // increment/decrement row and column input
 function increment (i, val){
@@ -70,6 +167,39 @@ function increment (i, val){
 
 function decrement (i, val){
     return +val -1;
+}
+
+// Build grid, based on event, and difference between current grid and input value
+function buildGrid(scale, axis){
+    countRows();
+    countColumns()
+    // Find out which button triggered the function
+    if (scale === increment && axis === inputRows){
+        // Compare input to current grid to add or remove accordingly
+        if (currentGridRows < inputRows.val()){
+            constructRows();
+        } else {
+            eliminateRows();
+        }
+    } else if (scale === decrement && axis === inputRows){
+        if (currentGridRows > inputRows.val()){
+            eliminateRows();
+        } else {
+            constructRows();
+        }
+    } else if (scale === increment && axis === inputColumns){
+        if (currentGridColumns < inputColumns.val()){
+            constructColumns();
+        } else {
+            eliminateColumns();
+        }
+    } else {
+        if (currentGridColumns > inputColumns.val()){
+            eliminateColumns();
+        } else {
+            constructColumns();
+        }
+    }
 }
 
 // Store difference between current rows/columns on screen and the input value
@@ -88,19 +218,6 @@ function countColumns(){
     let gridColumns = inputColumns.val();
     currentGridColumns = pixelCanvas.children().first().children().length;
     columnsDiff = Math.abs(gridColumns - currentGridColumns);
-}
-
-// Add/remove rows/columns buttons value
-let addRowBtnValue = addRowBtn.val();
-let removeRowBtnValue = removeRowBtn.val();
-let addColumnBtnValue = addColumnBtn.val();
-let removeColumnBtnValue = removeColumnBtn.val();
-
-// Build grid, update input, & update btn value. scale = increment or decrement. axis = row or column. btn = add/remove rows/columns buttons
-function gridBuilder (scale, axis, btn){
-    axis.val(scale);
-    buildGrid(scale, axis);
-    btn = axis.val();
 }
 
 // Functions to construct/eliminate rows/columns
@@ -135,80 +252,7 @@ function eliminateColumns(){
     }
 }
 
-// Build grid, based on event, and difference between current grid and input value
-function buildGrid(scale, axis){
-    countRows();
-    countColumns()
-    if (scale === increment && axis === inputRows){
-        if (currentGridRows < inputRows.val()){
-            constructRows();
-        } else {
-            eliminateRows();
-        }
-    } else if (scale === decrement && axis === inputRows){
-            if (currentGridRows > inputRows.val()){
-                eliminateRows();
-            } else {
-                constructRows();
-            }
-    } else if (scale === increment && axis === inputColumns){
-        if (currentGridColumns < inputColumns.val()){
-            constructColumns();
-        } else {
-            eliminateColumns();
-        }
-    } else {
-            if (currentGridColumns > inputColumns.val()){
-                eliminateColumns();
-            } else {
-                constructColumns();
-            }
-    }
-}
-
-// listen to change in input and update btn value
-inputRows.on('keyup mouseup', function(){
-    addRowBtnValue = inputRows.val();
-    removeRowBtnValue = inputRows.val();
-});
-
-inputColumns.on('keyup mouseup', function(){
-    addColumnBtnValue = inputColumns.val();
-    removeColumnBtnValue = inputColumns.val();
-});
-
-// Grid-building buttons event listeners
-let clickAndHold;
-
-addRowBtn.mousedown(function(){
-    clickAndHold = setInterval(function(){ gridBuilder(increment, inputRows, addRowBtnValue); }, 80);
-}).mouseup(function(){
-    clearInterval(clickAndHold);
-});
-
-removeRowBtn.mousedown(function(){
-    // builds missing rows before removing
-    buildGrid(increment, inputRows);
-    clickAndHold = setInterval(function(){ gridBuilder(decrement, inputRows, removeRowBtnValue); }, 80);
-}).mouseup(function(){
-    clearInterval(clickAndHold);
-});
-
-addColumnBtn.mousedown(function(){
-    // builds grid if it's not there yet
-    buildGrid(increment, inputRows);
-    clickAndHold = setInterval(function(){ gridBuilder(increment, inputColumns, addColumnBtnValue); }, 80);
-}).mouseup(function(){
-    clearInterval(clickAndHold);
-});
-
-removeColumnBtn.mousedown(function(){
-    // builds grid before removing column
-    buildGrid(increment, inputRows);
-    clickAndHold = setInterval(function(){ gridBuilder(decrement, inputColumns, removeColumnBtnValue); }, 80);
-}).mouseup(function(){
-    clearInterval(clickAndHold);
-});
+//////////////////////////////////////////////// ^ GRID BUILDER ^
 
 // DRAW
 // Grab color input on change
@@ -249,12 +293,12 @@ function drag () {
         }
     })
     .on('mousedown', function(){
-            event.preventDefault();
-            mouseIsDown = true;
-        })
-        .on('mouseup', function(){
-            mouseIsDown = false;
-        });
+        event.preventDefault();
+        mouseIsDown = true;
+    })
+    .on('mouseup', function(){
+        mouseIsDown = false;
+    });
     pixelCanvas.on('mouseleave', function(){
         mouseIsDown = false;
     });
@@ -262,8 +306,8 @@ function drag () {
 
 // Event listener click delegated
 pixelCanvas
-    .on('click', 'td', draw)
-    .on('mousedown', 'td', drag);
+.on('click', 'td', draw)
+.on('mousedown', 'td', drag);
 
 
 

--- a/designs.js
+++ b/designs.js
@@ -96,23 +96,23 @@ function decrement (i, val){
 let rowsDiff = 0;
 let columnsDiff = 0;
 function countRows(){
-    let currentGridRows = 0;
     let gridRows = inputRows.val();
+    let currentGridRows = 0;
     currentGridRows = pixelCanvas.children('tr').length;
     rowsDiff = gridRows - currentGridRows;
-    console.log(currentGridRows);
-    console.log(gridRows);
-    console.log(rowsDiff);
-}
-//////////////
-function countColumns(){
-    let currentGridColumns = 0;
-    let gridColumns = inputColumns.val();
-    currentGridColumns = pixelCanvas.children('td').length; //////////////
-    columnDiff = gridColumns - currentGridColumns;
     // console.log(currentGridRows);
     // console.log(gridRows);
     // console.log(rowsDiff);
+}
+//////////////
+function countColumns(){
+    let gridColumns = inputColumns.val();
+    let currentGridColumns = 0;
+    currentGridColumns = pixelCanvas.children().first().children().length;
+    columnsDiff = gridColumns - currentGridColumns;
+    // console.log(currentGridColumns);
+    // console.log(gridColumns);
+    // console.log(columnsDiff);
 }
 
 
@@ -132,6 +132,7 @@ function gridBuilder (scale, axis){
 // the main issue is that inputting numbers manually puts the Btns out of sync with the actual input
 function buildGrid(scale, axis){
     countRows();
+    countColumns()
     if (scale === increment && axis === inputRows){
         for (let r = 1; r <= rowsDiff; r++){
             const addRow = $("<tr></tr>");
@@ -142,11 +143,13 @@ function buildGrid(scale, axis){
             }
         }
     } else if (scale === decrement && axis === inputRows){
-        row.remove();
+        pixelCanvas.children().last().remove();
     } else if (scale === increment && axis === inputColumns){
         pixelCanvas.children().append(column);
     } else {
-        column.remove();
+        $('tr').each(function(){
+            $('td').last().remove(); ///////////////////////
+        });
     }
 }
 
@@ -160,7 +163,14 @@ removeRowBtn.click(function(){
 });
 
 addColumnBtn.click(function(){
-    gridBuilder(increment, inputColumns);
+    //Checks if there are rows already created
+    if ( pixelCanvas.children('tr').length ) {
+        gridBuilder(increment, inputColumns);
+    } else {
+        // Creates rows
+       buildGrid(increment, inputRows);
+        gridBuilder(increment, inputColumns);
+    }
 });
 
 removeColumnBtn.click(function(){

--- a/designs.js
+++ b/designs.js
@@ -91,10 +91,15 @@ function decrement (i, val){
     return +val -1;
 }
 
+// This with test = axis.val(); executed in gridBuilder, means the value of button and input are now always the same. maybe add btn param to make it work for all four buttons
+let test = addRowBtn.val();
+
 // Build grid & update input. scale = increment or decrement. axis = row or column
 function gridBuilder (scale, axis){
     axis.val(scale);
     buildGrid(scale, axis);
+    test = axis.val();
+    console.log(test);
 }
 
 ////////////////////////////////////////////////////

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
     <div class="controls">
         <h2>Build Your Grid</h2>
         <label class="builder"><div>Row</div>
-            <button type="button" id="remove-row">-</button>
-            <button type="button" id="add-row">+</button>
+            <button type="button" id="remove-row" value="10">-</button>
+            <button type="button" id="add-row" value="10">+</button>
             <input type="number" id="input-rows" name="height" min="1" max="150" value="10">
             <span class="validity"></span>
         </label>
 
         <label class="builder"><div>Column</div>
-            <button type="button" id="remove-column">-</button>
-            <button type="button" id="add-column">+</button>
+            <button type="button" id="remove-column" value="10">-</button>
+            <button type="button" id="add-column" value="10">+</button>
             <input type="number" id="input-columns" name="width" min="1" max="150" value="10">
             <span class="validity"></span>
         </label>

--- a/index.html
+++ b/index.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Pixel Art Maker!</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Monoton">
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Syk's Pixel Art</title>
+    <link href="https://fonts.googleapis.com/css?family=Gloria+Hallelujah" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 </head>
 <body>
     <h1>Pixel Art Maker</h1>
 
-    <h2>Build Your Grid</h2>
-    <label>Row
-        <button type="button" id="remove-row">-</button>
-        <button type="button" id="add-row">+</button>
-    </label>
-    <label>Column
-        <button type="button" id="remove-column">-</button>
-        <button type="button" id="add-column">+</button>
-    </label>
+    <div class="controls">
+        <h2>Build Your Grid</h2>
+        <label class="builder"><div>Row</div>
+            <button type="button" id="remove-row">-</button>
+            <button type="button" id="add-row">+</button>
+            <input type="number" id="input-rows" name="height" min="1" max="150" value="10">
+            <span class="validity"></span>
+        </label>
 
-    <p>Or</p>
+        <label class="builder"><div>Column</div>
+            <button type="button" id="remove-column">-</button>
+            <button type="button" id="add-column">+</button>
+            <input type="number" id="input-columns" name="width" min="1" max="150" value="10">
+            <span class="validity"></span>
+        </label>
 
-    <h2>Choose Grid Size</h2>
-    <form id="size-picker">
-        Rows:
-        <input type="number" id="input-rows" name="height" min="1" max="150" value="10">
-        <span class="validity"></span>
-        Columns:
-        <input type="number" id="input-columns" name="width" min="1" max="150" value="10">
-        <span class="validity"></span>
-        <button type="button" id="submit-grid">Create Grid</button>
-    </form>
-    <button type="button" id="reset">Reset</button>
+        <button type="button" id="submit-grid">Create/Clear Grid</button>
+        <button type="button" id="reset">Reset</button>
 
-    <h2>Pick A Color</h2>
-    <input type="color" id="color-picker">
+        <h2>Pick A Color</h2>
+        <input type="color" id="color-picker">
 
-    <h2>Design Canvas</h2>
+        <h2>Draw Something!</h2>
+    </div>
+
     <table id="pixel-canvas"></table>
+
+    <footer><p>Take a screenshot of your masterpiece, click Tweet, paste it, and tweet it right back at me!</p>
+        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I made this masterpiece with this Pixel Art maker" data-via="Syknapse" data-hashtags="100DaysofCode" data-show-count="false" title="tweeet">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script><br>
+        <a href="https://syknapse.github.io/Syk-Houdeib" title="Portfolio & Contact">Syk Houdeib 2018</a></footer>
 
     <script src="designs.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,17 @@
 body {
     text-align: center;
+    font-family: 'Gloria Hallelujah', cursive;
 }
 
 h1 {
-    font-family: Monoton;
-    font-size: 70px;
+    font-family: 'Gloria Hallelujah', cursive;
+    font-size: 50px;
     margin: 0.2em;
 }
 
 h2 {
-    margin: 1em 0 0.25em;
+    /* margin: 0.5em 0 0.25em; */
+    font-size: 0.9em;
 }
 
 h2:first-of-type {
@@ -25,6 +27,7 @@ td {
 table {
     border-collapse: collapse;
     margin: 0 auto;
+    max-width: 96%;
 }
 
 tr {
@@ -36,15 +39,73 @@ td {
 }
 
 input[type=number] {
-    width: 6em;
+    width: 3em;
+}
+
+button {
+    font-family: 'Gloria Hallelujah', cursive;
+    background-color: rgb(245, 255, 245);
+    border-radius: 30px;
+    border: 2px solid black;
+}
+
+.builder {
+    width: 300px;
+    display: flex;
+    justify-content: space-around;
+}
+
+.builder button {
+    width: 80px;
+}
+
+.builder div {
+    width: 60px;
+    margin-right: 5px;
 }
 
 input:invalid+span:after {
-    content: '✖ (150 max)';
+    content: '✖ (min 1, max 150)';
     padding-left: 5px;
   }
 
 input:valid+span:after {
     content: '✓';
     padding-left: 5px;
+}
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.controls > * {
+    margin: 0.5em;
+}
+
+#submit-grid,
+#reset {
+    width: 160px;
+}
+
+#color-picker {
+    height: 50px;
+    width: 50px;
+}
+
+footer {
+    margin-top: 20%;
+    font-size: 0.8em;
+}
+
+footer a {
+    text-decoration: none;
+}
+
+
+@media screen and (max-width: 780px){
+    h1 {
+        font-size: 40px;
+    }
 }


### PR DESCRIPTION
Complete feature that allows to dynamically add/remove rows/columns without resetting grid ie drawing persists.
User can construct grid, construct or eliminate rows/columns by:
+ click on any of the four +/- buttons,
+ click and hold on any of the four +/- buttons to create multiple,
+ change value in row/column input field with the arrow or manually then hit enter,
+ change value in row/column input field with the arrow or manually then click +/- buttons,